### PR TITLE
Add Pesty to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ _Note: 🔶 denotes projects written in Swift._
 - [Clocker](https://github.com/Abhishaker17/Clocker) - A menubar utility for keeping track of your friends/colleagues in different timezones.
 - [2FHey](https://github.com/SoFriendly/2fhey) - iMessage AutoFill For Any Browser. Auto-copy 2FA & OTP codes into Firefox & Google Chrome
 - [Agent Island](https://github.com/tristan666666/agent-island) - MacBook notch companion for Claude Code and Codex sessions with live status and auto-resume for selected long-running tasks. 🔶
+- [Pesty](https://github.com/momenbasel/pesty) - A native SwiftUI clipboard manager with a slide-up, color-coded clipboard strip, pinboards, instant search, and keyboard-driven pasting. 🔶
 
 ## Contributing
 [See the guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
### What

Adds [Pesty](https://github.com/momenbasel/pesty) to the **Apps** section.

Pesty is a free, open-source (MIT), native SwiftUI clipboard manager for macOS — a slide-up, color-coded clipboard strip with pinboards, instant search, and keyboard-driven pasting.

### Why it fits this list

- **Open source macOS project** — MIT licensed, source on GitHub: https://github.com/momenbasel/pesty
- **Written in Swift** — pure SwiftUI, so it carries the 🔶 marker like other Swift entries (Agent Island, gInbox).
- **Native and actively maintained** — universal binary, Developer ID signed + Apple-notarized, zero third-party dependencies, recently pushed.
- **Easy to try** — `brew install --cask momenbasel/pesty/pesty`.
- Sits naturally alongside existing utility apps in the section (Spectacle, Clocker, 2FHey).

### Checklist (per CONTRIBUTING)

- [x] Searched existing entries — no duplicate.
- [x] Format `[PACKAGE](LINK) - DESCRIPTION.` with trailing period.
- [x] Added as the last item in the category.
- [x] Swift project — added 🔶 at the end.
- [x] Single entry, single PR. Spelling/grammar checked, no trailing whitespace.

Landing page: https://www.moamenbasel.com/pesty/