### PR TITLE
Add Dusty to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ _Note: 🔶 denotes projects written in Swift._
 - [Agent Island](https://github.com/tristan666666/agent-island) - Native macOS menu bar companion for Claude Code and Codex session status and your-turn alerts. 🔶
 - [Pesty](https://github.com/momenbasel/pesty) - A native SwiftUI clipboard manager with a slide-up, color-coded clipboard strip, pinboards, instant search, and keyboard-driven pasting. 🔶
 - [Core-Monitor](https://github.com/offyotto/Core-Monitor) - Native Apple Silicon system monitor with dashboard and menu bar views, hardware metrics, and optional fan control. :large_orange_diamond:
+- [Dusty](https://github.com/yagcioglutoprak/dusty) - A free, open-source macOS menu-bar disk cleaner with preview-first, allowlist-based cleanup. :large_orange_diamond:
 
 ## Contributing
 [See the guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
I represent Dusty and am submitting it for consideration.\n\nThis PR makes the single README addition required by the contribution guide. Dusty is a free, MIT-licensed, open-source macOS disk cleaner with a preview-first workflow and documented allowlisted cleanup targets. The entry is placed as the last item in the Apps section and marks the Swift implementation using the repository's existing convention.\n\nI searched the current README and all-state issues and pull requests immediately before opening this PR; no existing Dusty entry or prior submission was found.