### PR TITLE
Add AI Dictation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ _Note: 🔶 denotes projects written in Swift._
 - [Pesty](https://github.com/momenbasel/pesty) - A native SwiftUI clipboard manager with a slide-up, color-coded clipboard strip, pinboards, instant search, and keyboard-driven pasting. 🔶
 - [Core-Monitor](https://github.com/offyotto/Core-Monitor) - Native Apple Silicon system monitor with dashboard and menu bar views, hardware metrics, and optional fan control. :large_orange_diamond:
 - [Dusty](https://github.com/yagcioglutoprak/dusty) - A free, open-source macOS menu-bar disk cleaner with preview-first, allowlist-based cleanup. :large_orange_diamond:
+- [AI Dictation](https://github.com/writingmate/aidictation) - Native voice-to-text app with a global shortcut, offline recognition on supported Macs, and optional cloud transcription and cleanup. :large_orange_diamond:
 
 ## Contributing
 [See the guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
## What changed

Added one AI Dictation entry as the final item in the Apps category, using the required description format and Swift marker.

AI Dictation is an MIT-licensed native macOS voice-to-text app with a global shortcut, offline recognition on supported Macs, and optional cloud transcription and cleanup.

## Validation

- Searched the list, open and closed pull requests, and issues for duplicates.
- Checked the current project source, MIT license, website, and contribution guide.
- Ran `git diff --check` and verified the source link.

## Disclosure

I am affiliated with AI Dictation and am submitting it openly rather than presenting this as an independent recommendation. This entry and pull-request text were prepared with AI assistance, then checked against the current project and this repository's contribution guide.
