### PR TITLE
Add claude-session-tint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ _Note: 🔶 denotes projects written in Swift._
 - [Core-Monitor](https://github.com/offyotto/Core-Monitor) - Native Apple Silicon system monitor with dashboard and menu bar views, hardware metrics, and optional fan control. :large_orange_diamond:
 - [Dusty](https://github.com/yagcioglutoprak/dusty) - A free, open-source macOS menu-bar disk cleaner with preview-first, allowlist-based cleanup. :large_orange_diamond:
 - [AI Dictation](https://github.com/writingmate/aidictation) - Native voice-to-text app with a global shortcut, offline recognition on supported Macs, and optional cloud transcription and cleanup. :large_orange_diamond:
+- [claude-session-tint](https://github.com/dotcomjack/claude-session-tint) - Tints each Terminal.app window by project and lights up the Claude Code session that finished while you were looking elsewhere.
 
 ## Contributing
 [See the guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Adds [claude-session-tint](https://github.com/dotcomjack/claude-session-tint), a Terminal.app companion for Claude Code that tints each window by project and lights up whichever session finished while you were looking elsewhere.

Closest existing neighbour is Agent Island, which solves the same problem from the menu bar; this one puts the signal in the terminal window itself.

Guidelines checked: open source (MIT, link is the source), positioned as the last item in its category, description ends with a period, no trailing whitespace, individual PR. No orange diamond, since this is bash and AppleScript rather than Swift.