### PR TITLE
Add Nocturne

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ _Note: 🔶 denotes projects written in Swift._
 - [Dusty](https://github.com/yagcioglutoprak/dusty) - A free, open-source macOS menu-bar disk cleaner with preview-first, allowlist-based cleanup. :large_orange_diamond:
 - [AI Dictation](https://github.com/writingmate/aidictation) - Native voice-to-text app with a global shortcut, offline recognition on supported Macs, and optional cloud transcription and cleanup. :large_orange_diamond:
 - [claude-session-tint](https://github.com/dotcomjack/claude-session-tint) - Tints each Terminal.app window by project and lights up the Claude Code session that finished while you were looking elsewhere.
+- [Nocturne](https://github.com/dotcomjack/nocturne) - Makes the menu bar clock unreadable so it stops telling you how late it is, using one Apple preference key and no private APIs. :large_orange_diamond:
 
 ## Contributing
 [See the guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Adding [Nocturne](https://github.com/dotcomjack/nocturne), an MIT-licensed native macOS menu bar app.

The menu bar clock is the one menu bar item macOS ships no visibility toggle for, so Nocturne makes it unreadable rather than hidden: it flips `com.apple.menuextra.clock IsAnalog`, swapping the digital readout for a small analog dial.

Following the guide: positioned as the last item in Apps, description ends with a period, and it carries :large_orange_diamond: since it is written in Swift.